### PR TITLE
feat: add VR ESL support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "extern/CommonLibSSE-NG"]
+	path = extern/CommonLibSSE-NG
+	url = https://github.com/alandtse/CommonLibVR.git
+	branch = ng

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,10 +10,27 @@ project(
   LANGUAGES CXX
 )
 
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Version.h.in
+  ${CMAKE_CURRENT_BINARY_DIR}/include/Version.h
+  @ONLY
+)
+
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/cmake/version.rc.in
+  ${CMAKE_CURRENT_BINARY_DIR}/version.rc
+  @ONLY
+)
+
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_INTERPROCEDURAL_OPTIMIZATION ON)
 set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_DEBUG OFF)
+
+add_compile_definitions(SKYRIM)
+set(CommonLibPath "extern/CommonLibSSE-NG")
+set(GameVersion "Skyrim")
+set(CommonLibName "CommonLibSSE")
 
 configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/cmake/version.rc.in
@@ -46,17 +63,24 @@ source_group(
 ########################################################################################################################
 ## Configure target DLL
 ########################################################################################################################
-find_package(CommonLibSSE CONFIG REQUIRED)
+if (DEFINED CommonLibPath AND NOT ${CommonLibPath} STREQUAL "" AND IS_DIRECTORY ${CommonLibPath})
+  add_subdirectory(${CommonLibPath} ${CommonLibName} EXCLUDE_FROM_ALL)
+else ()
+  message(
+    FATAL_ERROR
+    "Variable ${CommonLibName}Path is not set."
+  )
+endif()
 
-add_commonlibsse_plugin(
+add_library(
   ${PROJECT_NAME}
-  AUTHOR ModiLogist
-  USE_ADDRESS_LIBRARY
-  USE_SIGNATURE_SCANNING
-  SOURCES ${headers} ${sources}
+  SHARED
+  ${headers}
+  ${sources}
+  ${CMAKE_CURRENT_BINARY_DIR}/include/Version.h
+  ${CMAKE_CURRENT_BINARY_DIR}/version.rc
+  .clang-format
 )
-
-add_library("${PROJECT_NAME}::${PROJECT_NAME}" ALIAS "${PROJECT_NAME}")
 
 target_compile_definitions(
     ${PROJECT_NAME}
@@ -88,6 +112,12 @@ target_include_directories(
   ${PROJECT_NAME}
   PRIVATE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc>
+)
+
+target_link_libraries(
+  ${PROJECT_NAME}
+  PUBLIC
+    ${CommonLibName}::${CommonLibName}
 )
 
 target_precompile_headers(

--- a/cmake/Version.h.in
+++ b/cmake/Version.h.in
@@ -1,0 +1,10 @@
+#pragma once
+
+namespace Version
+{
+	inline constexpr std::size_t MAJOR = @PROJECT_VERSION_MAJOR@;
+	inline constexpr std::size_t MINOR = @PROJECT_VERSION_MINOR@;
+	inline constexpr std::size_t PATCH = @PROJECT_VERSION_PATCH@;
+	inline constexpr auto NAME = "@PROJECT_VERSION@"sv;
+	inline constexpr auto PROJECT = "@PROJECT_NAME@"sv;
+}

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -40,6 +40,15 @@ void EventListener(SKSE::MessagingInterface::Message* aMessage) noexcept {
   }
 }
 
+extern "C" __declspec(dllexport) bool SKSEAPI SKSEPlugin_Query(const SKSE::QueryInterface* a_skse, SKSE::PluginInfo* a_info) {
+  a_info->infoVersion = SKSE::PluginInfo::kVersion;
+  a_info->name = "TheNewGentleman";
+  a_info->version = 2;
+
+  return true;
+}
+
+
 SKSEPluginLoad(const SKSE::LoadInterface* aSkse) {
   const auto lPlugin{SKSE::PluginDeclaration::GetSingleton()};
   const auto lVersion{lPlugin->GetVersion()};

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "thenewgentleman",
-  "dependencies": [ "commonlibsse-ng", "simpleini" ],
+  "dependencies": [ "simpleini", "directxtk", "rapidcsv", "fmt", "spdlog", "catch2" ],
   "license": "MIT",
   "vcpkg-configuration": {
     "default-registry": {


### PR DESCRIPTION
Swapped CLIB-NG to Alan's CLIB-NG which includes VR ESL support natively

Note: One static_assertion within CLIB-NG for `InputContext` needs to be disabled for now. This is untested, but should work out of the box