### PR TITLE
fix: Unguarded call for GetFormFromFile

### DIFF
--- a/mod/TNG_MCM.psc
+++ b/mod/TNG_MCM.psc
@@ -151,7 +151,7 @@ EndEvent
 
 Event OnGameReload()
   Parent.OnGameReload()
-  If Game.GetModByName("Dynamic Activation Key.esp")
+  If Game.GetModByName("Dynamic Activation Key.esp") != 255
     fkDAK = Game.GetFormFromFile(0x801, "Dynamic Activation Key.esp") As GlobalVariable
   EndIf
   Int liKey = 5
@@ -179,7 +179,7 @@ Event OnPageReset(String asPage)
     AddHeaderOption("$TNG_KyH")
     AddHeaderOption("")
     fkDAK = None
-    If Game.GetModByName("Dynamic Activation Key.esp")
+    If Game.GetModByName("Dynamic Activation Key.esp") != 255
       fkDAK = Game.GetFormFromFile(0x801, "Dynamic Activation Key.esp") As GlobalVariable
       If fkDAK
         fiDAKHdl = AddToggleOption("$TNG_DAK", TNG_PapyrusUtil.GetBoolValue(cbDAK))


### PR DESCRIPTION
The condition `Game.GetModByName("Dynamic Activation Key.esp")` is not operating as expected.

As a cast to Bool, Ints provide TRUE for non-zero values, whereas [GetModByName provides the Integer 255 if function returns False](https://ck.uesp.net/wiki/GetModByName_-_Game). Consequently, this condition never returns False unless plugin occupies load index 0 (which only occurs theoretically with a present plugin or if SKSE isn't installed).

Resulting Papyrus Log Error:
```
[05/06/2026 - 12:47:34AM] error: File "Dynamic Activation Key.esp" does not exist or is not currently loaded.
stack:
	<unknown self>.Game.GetFormFromFile() - "<native>" Line ?
	[TNG_MCM (FE008F00)].TNG_MCM.OnGameReload() - "TNG_MCM.psc" Line 155
	[TNG_MCM (FE008F00)].TNG_MCM.OnInit() - "SKI_ConfigBase.psc" Line 85